### PR TITLE
[Feat] 이미지 업로드/삭제 기능 및 공통 예외 처리 도입 (#1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,15 @@ dependencies {
 
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// AWS s3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/cokathon/CokathonApplication.java
+++ b/src/main/java/com/example/cokathon/CokathonApplication.java
@@ -2,7 +2,9 @@ package com.example.cokathon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CokathonApplication {
 

--- a/src/main/java/com/example/cokathon/global/config/S3Config.java
+++ b/src/main/java/com/example/cokathon/global/config/S3Config.java
@@ -1,0 +1,37 @@
+package com.example.cokathon.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import lombok.NoArgsConstructor;
+
+@Configuration
+@NoArgsConstructor
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.accessKey}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secretKey}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+		return (AmazonS3Client)
+			AmazonS3ClientBuilder.standard()
+				.withRegion(region)
+				.withCredentials(new AWSStaticCredentialsProvider(credentials))
+				.build();
+	}
+}
+

--- a/src/main/java/com/example/cokathon/global/dto/BaseResponse.java
+++ b/src/main/java/com/example/cokathon/global/dto/BaseResponse.java
@@ -1,0 +1,22 @@
+package com.example.cokathon.global.dto;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseResponse {
+
+	private final String status;
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+	private final LocalDateTime timestamp = LocalDateTime.now();
+
+	protected BaseResponse(HttpStatus status) {
+		this.status = status.getReasonPhrase();
+	}
+}

--- a/src/main/java/com/example/cokathon/global/dto/DataResponse.java
+++ b/src/main/java/com/example/cokathon/global/dto/DataResponse.java
@@ -1,0 +1,32 @@
+package com.example.cokathon.global.dto;
+
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DataResponse<T> extends BaseResponse {
+
+	private final T data;
+
+	private DataResponse(HttpStatus status, T data) {
+		super(status);
+		this.data = data;
+	}
+
+	public static <T> DataResponse<T> from(T data) {
+		return new DataResponse<>(HttpStatus.OK, data);
+	}
+
+	public static <T> DataResponse<Void> ok() {
+		return new DataResponse<>(HttpStatus.OK, null);
+	}
+
+	public static <T> DataResponse<Void> created() {
+		return new DataResponse<>(HttpStatus.CREATED, null);
+	}
+}
+

--- a/src/main/java/com/example/cokathon/global/dto/ErrorResponse.java
+++ b/src/main/java/com/example/cokathon/global/dto/ErrorResponse.java
@@ -1,0 +1,54 @@
+package com.example.cokathon.global.dto;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.cokathon.global.exception.GlobalErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse extends BaseResponse {
+
+	private final String message;
+	private final Map<String, String> reasons;
+	private final String code;
+
+	private ErrorResponse(
+		HttpStatus status,
+		String message,
+		String code,
+		Map<String, String> reasons
+	) {
+		super(status);
+		this.message = message;
+		this.reasons = reasons;
+		this.code = code;
+	}
+
+	public static ErrorResponse from(GlobalErrorCode errorCode) {
+		HttpStatus status = errorCode.getHttpStatus();
+		String message = errorCode.getMessage();
+		String code = errorCode.getCode();
+
+		return new ErrorResponse(status, message, code, null);
+	}
+
+	public static ErrorResponse of(GlobalErrorCode errorCode, Map<String, String> reasons) {
+		HttpStatus status = errorCode.getHttpStatus();
+		String message = errorCode.getMessage();
+		String code = errorCode.getCode();
+
+		return new ErrorResponse(status, message, code, reasons);
+	}
+
+	public static ErrorResponse of(HttpStatus httpStatus, String message, String code) {
+
+		return new ErrorResponse(httpStatus, message, code, null);
+	}
+
+}
+

--- a/src/main/java/com/example/cokathon/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/cokathon/global/entity/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.example.cokathon.global.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass // 이 클래스를 직접 테이블로 매핑하지 않고, 자식 클래스에 매핑 정보를 전달하도록 설정
+@EntityListeners(AuditingEntityListener.class) // JPA 엔티티의 상태 변화를 감지하여 Auditing(자동 필드 값 설정)을 수행하는 리스너를 추가
+public abstract class BaseEntity {
+
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	@CreatedDate
+	@Column(updatable = false, nullable = false)
+	private LocalDateTime createdDate;
+
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	@LastModifiedDate
+	@Column(nullable = false)
+	private LocalDateTime modifiedDate;
+}
+

--- a/src/main/java/com/example/cokathon/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/example/cokathon/global/exception/GlobalErrorCode.java
@@ -1,0 +1,25 @@
+package com.example.cokathon.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode {
+
+	// 400 Error Code, 클라이언트 측 오류
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "CLIENT_ERROR_400"),
+	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "유효하지 않은 파라미터입니다.", "CLIENT_ERROR_400_INVALID_PARAMETER"),
+
+	// 404 Error Code, 리소스가 존재하지 않을 때
+	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스가 존재하지 않습니다.", "CLIENT_ERROR_404_RESOURCE_NOT_FOUND"),
+
+	// 500 Error Code, 서버 측 오류
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", "SERVER_ERROR_500");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+	private final String code;
+}

--- a/src/main/java/com/example/cokathon/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/cokathon/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,53 @@
+package com.example.cokathon.global.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.example.cokathon.global.dto.ErrorResponse;
+import com.example.cokathon.image.exception.ImageException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<Object> handleValidationExceptions(MethodArgumentNotValidException e) {
+		Map<String, String> errors = new HashMap<>();
+		e.getBindingResult().getAllErrors()
+			.forEach(error -> errors.put(((FieldError)error).getField(), error.getDefaultMessage()));
+
+		log.error("MethodArgumentNotValidException: {}", errors);
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse.of(GlobalErrorCode.INVALID_PARAMETER, errors));
+	}
+
+	@ExceptionHandler(ImageException.class)
+	public ResponseEntity<Object> handleImageException(ImageException e) {
+		log.error("ImageException: {}", e.getMessage(), e);
+
+		return ResponseEntity
+			.status(e.getHttpStatus())
+			.body(ErrorResponse.of(e.getHttpStatus(), e.getMessage(), e.getCode()));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<Object> handleAllExceptions(Exception e) {
+		log.error("Unhandled exception: {}", e.getMessage(), e);
+
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ErrorResponse.from(GlobalErrorCode.INTERNAL_SERVER_ERROR));
+	}
+
+}

--- a/src/main/java/com/example/cokathon/image/controller/ImageController.java
+++ b/src/main/java/com/example/cokathon/image/controller/ImageController.java
@@ -1,0 +1,38 @@
+package com.example.cokathon.image.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.cokathon.global.dto.DataResponse;
+import com.example.cokathon.image.dto.response.ImageIdResponse;
+import com.example.cokathon.image.service.ImageService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/v1/image")
+@RestController
+@RequiredArgsConstructor
+public class ImageController {
+
+	private final ImageService imageService;
+
+	@PostMapping(consumes = "multipart/form-data")
+	public ResponseEntity<DataResponse<ImageIdResponse>> addImageToTemp(
+		final @RequestParam MultipartFile file) {
+
+		return ResponseEntity.ok(DataResponse.from(imageService.addImageToTemp(file)));
+	}
+
+	@DeleteMapping("/{imageId}")
+	public ResponseEntity<DataResponse<Void>> deleteImage(final @PathVariable("imageId") long imageId) {
+
+		imageService.deleteImage(imageId);
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+}

--- a/src/main/java/com/example/cokathon/image/domain/Image.java
+++ b/src/main/java/com/example/cokathon/image/domain/Image.java
@@ -1,0 +1,39 @@
+package com.example.cokathon.image.domain;
+
+import com.example.cokathon.global.entity.BaseEntity;
+import com.example.cokathon.image.dto.ImageDTO;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "images")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "s3_info")
+	private S3Info s3Info;
+
+	private Image(S3Info s3Info) {
+		this.s3Info = s3Info;
+	}
+
+	public static Image from(final ImageDTO imageDTO) {
+		return new Image(
+			S3Info.from(imageDTO.s3InfoDTO())
+		);
+	}
+}

--- a/src/main/java/com/example/cokathon/image/domain/S3Info.java
+++ b/src/main/java/com/example/cokathon/image/domain/S3Info.java
@@ -1,0 +1,27 @@
+package com.example.cokathon.image.domain;
+
+import com.example.cokathon.image.dto.S3InfoDTO;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class S3Info {
+	private String folderName;
+	private String fileName;
+	private String url;
+
+	private S3Info(String folderName, String fileName, String url) {
+		this.folderName = folderName;
+		this.fileName = fileName;
+		this.url = url;
+	}
+
+	public static S3Info from(S3InfoDTO s3InfoDTO) {
+		return new S3Info(s3InfoDTO.folderName(), s3InfoDTO.fileName(), s3InfoDTO.url());
+	}
+}

--- a/src/main/java/com/example/cokathon/image/dto/ImageDTO.java
+++ b/src/main/java/com/example/cokathon/image/dto/ImageDTO.java
@@ -1,0 +1,9 @@
+package com.example.cokathon.image.dto;
+
+public record ImageDTO(
+		S3InfoDTO s3InfoDTO
+) {
+	public static ImageDTO from(final S3InfoDTO s3InfoDTO) {
+		return new ImageDTO(s3InfoDTO);
+	}
+}

--- a/src/main/java/com/example/cokathon/image/dto/S3InfoDTO.java
+++ b/src/main/java/com/example/cokathon/image/dto/S3InfoDTO.java
@@ -1,0 +1,17 @@
+package com.example.cokathon.image.dto;
+
+import com.example.cokathon.image.domain.S3Info;
+
+public record S3InfoDTO(
+		String folderName,
+		String fileName,
+		String url
+) {
+	public static S3InfoDTO of(String folderName, String fileName, String url) {
+		return new S3InfoDTO(folderName, fileName, url);
+	}
+
+	public static S3InfoDTO from(S3Info s3Info) {
+		return new S3InfoDTO(s3Info.getFolderName(), s3Info.getFileName(), s3Info.getUrl());
+	}
+}

--- a/src/main/java/com/example/cokathon/image/dto/response/ImageIdResponse.java
+++ b/src/main/java/com/example/cokathon/image/dto/response/ImageIdResponse.java
@@ -1,0 +1,9 @@
+package com.example.cokathon.image.dto.response;
+
+public record ImageIdResponse(
+		Long imageId
+) {
+	public static ImageIdResponse from(final Long imageId) {
+		return new ImageIdResponse(imageId);
+	}
+}

--- a/src/main/java/com/example/cokathon/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/example/cokathon/image/exception/ImageErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.cokathon.image.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode {
+
+	IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다.", "IMAGE_ERROR_404_NOT_FOUND"),
+	IMAGE_PROCESSING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 처리에 실패했습니다.", "IMAGE_ERROR_500_PROCESSING_FAIL");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+	private final String code;
+
+}

--- a/src/main/java/com/example/cokathon/image/exception/ImageException.java
+++ b/src/main/java/com/example/cokathon/image/exception/ImageException.java
@@ -1,0 +1,24 @@
+package com.example.cokathon.image.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+public class ImageException extends RuntimeException {
+
+	private final HttpStatus httpStatus;
+	private final String code;
+
+	private ImageException(String message, HttpStatus httpStatus, String code) {
+		super(message);
+		this.httpStatus = httpStatus;
+		this.code = code;
+	}
+
+	public static ImageException from(ImageErrorCode errorCode) {
+		return new ImageException(errorCode.getMessage(), errorCode.getHttpStatus(), errorCode.getCode());
+	}
+}

--- a/src/main/java/com/example/cokathon/image/repository/ImageRepository.java
+++ b/src/main/java/com/example/cokathon/image/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package com.example.cokathon.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.cokathon.image.domain.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/example/cokathon/image/service/ImageService.java
+++ b/src/main/java/com/example/cokathon/image/service/ImageService.java
@@ -1,0 +1,12 @@
+package com.example.cokathon.image.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.cokathon.image.dto.response.ImageIdResponse;
+
+public interface ImageService {
+
+	ImageIdResponse addImageToTemp(final MultipartFile file);
+
+	void deleteImage(final long imageId);
+}

--- a/src/main/java/com/example/cokathon/image/service/impl/ImageServiceImpl.java
+++ b/src/main/java/com/example/cokathon/image/service/impl/ImageServiceImpl.java
@@ -1,0 +1,44 @@
+package com.example.cokathon.image.service.impl;
+
+import static com.example.cokathon.image.exception.ImageErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.cokathon.image.domain.Image;
+import com.example.cokathon.image.dto.ImageDTO;
+import com.example.cokathon.image.dto.S3InfoDTO;
+import com.example.cokathon.image.dto.response.ImageIdResponse;
+import com.example.cokathon.image.exception.ImageException;
+import com.example.cokathon.image.repository.ImageRepository;
+import com.example.cokathon.image.service.ImageService;
+import com.example.cokathon.image.service.s3.S3Uploader;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+
+	private final ImageRepository imageRepository;
+
+	private final S3Uploader s3Uploader;
+
+	private static final String TEMP_FOLDER = "temp";
+
+	@Override
+	public ImageIdResponse addImageToTemp(final MultipartFile file) {
+		S3InfoDTO s3InfoDTO = s3Uploader.uploadFiles(file, TEMP_FOLDER);
+		Image image = imageRepository.save(Image.from(ImageDTO.from(s3InfoDTO)));
+		return ImageIdResponse.from(image.getId());
+	}
+
+	@Override
+	public void deleteImage(final long imageId) {
+		Image image = imageRepository.findById(imageId)
+			.orElseThrow(() -> ImageException.from(IMAGE_NOT_FOUND));
+		s3Uploader.deleteFile(S3InfoDTO.from(image.getS3Info()));
+		imageRepository.delete(image);
+	}
+
+}

--- a/src/main/java/com/example/cokathon/image/service/s3/S3Uploader.java
+++ b/src/main/java/com/example/cokathon/image/service/s3/S3Uploader.java
@@ -1,0 +1,104 @@
+package com.example.cokathon.image.service.s3;
+
+import static com.example.cokathon.image.exception.ImageErrorCode.*;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.cokathon.image.dto.S3InfoDTO;
+import com.example.cokathon.image.exception.ImageException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3Uploader {
+	private final AmazonS3Client amazonS3;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	/**
+	 * 이미지 파일을 S3에 업로드하고 정보 반환
+	 */
+	public S3InfoDTO uploadFiles(MultipartFile multipartFile, String folderName) throws ImageException {
+		File localFile = convertMultipartFile(multipartFile);
+		return uploadFileToS3(localFile, folderName);
+	}
+
+	/**
+	 * S3에서 파일 삭제
+	 */
+	public void deleteFile(S3InfoDTO s3Info) {
+		String fileName = buildFilePath(s3Info.folderName(), s3Info.fileName());
+		amazonS3.deleteObject(bucket, fileName);
+	}
+
+	/**
+	 * S3 업로드 + 로컬 파일 삭제
+	 */
+	private S3InfoDTO uploadFileToS3(File file, String folderName) {
+		String fileName = buildFilePath(folderName, file.getName());
+
+		// S3 업로드
+		PutObjectRequest request = new PutObjectRequest(bucket, fileName, file)
+			.withCannedAcl(CannedAccessControlList.PublicRead);
+		amazonS3.putObject(request);
+
+		// 업로드된 URL 획득
+		String url = amazonS3.getUrl(bucket, fileName).toString();
+
+		// 로컬 파일 삭제
+		if (!file.delete()) {
+			log.error("Failed to delete local file: {}", file.getAbsolutePath());
+		}
+
+		return S3InfoDTO.of(folderName, file.getName(), url);
+	}
+
+	/**
+	 * MultipartFile을 로컬 임시 File로 변환
+	 */
+	private File convertMultipartFile(MultipartFile file) throws ImageException {
+		String extension = extractExtension(file);
+		String tempFileName = UUID.randomUUID() + "." + extension;
+		File localFile = new File(System.getProperty("user.dir"), tempFileName);
+
+		try (FileOutputStream fos = new FileOutputStream(localFile)) {
+			fos.write(file.getBytes());
+		} catch (IOException e) {
+			throw ImageException.from(IMAGE_PROCESSING_FAIL);
+		}
+
+		return localFile;
+	}
+
+	/**
+	 * 파일 확장자 추출
+	 */
+	private String extractExtension(MultipartFile file) throws ImageException {
+		String originalFilename = file.getOriginalFilename();
+		if (originalFilename == null || !originalFilename.contains(".")) {
+			throw ImageException.from(IMAGE_NOT_FOUND);
+		}
+		return originalFilename.substring(originalFilename.lastIndexOf('.') + 1);
+	}
+
+	/**
+	 * S3 내 파일 경로 생성
+	 */
+	private String buildFilePath(String folder, String filename) {
+		return folder + "/" + filename;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
     name: cokaton
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}  # ?? ????? 'local'? ??
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 springdoc:
   swagger-ui:
@@ -13,6 +17,16 @@ springdoc:
     tags-sorter: alpha  # ??? ??? ??? ??
     operations-sorter: method  # delete ? get ? patch ? post ? put ? ??
   use-fqn: true
+
+cloud:
+  aws:
+    s3:
+      bucket: ${BUCKET_ADDRESS}
+    stack.auto: false
+    region.static: ap-northeast-2
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_ACCESS_PASSWORD}
 
 ---
 spring:

--- a/src/test/java/com/example/cokathon/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/example/cokathon/image/controller/ImageControllerTest.java
@@ -1,0 +1,105 @@
+package com.example.cokathon.image.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.example.cokathon.global.exception.GlobalExceptionHandler;
+import com.example.cokathon.image.dto.response.ImageIdResponse;
+import com.example.cokathon.image.exception.ImageErrorCode;
+import com.example.cokathon.image.exception.ImageException;
+import com.example.cokathon.image.service.ImageService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class ImageControllerTest {
+
+	private MockMvc mockMvc;
+	private ObjectMapper objectMapper;
+
+	@Mock
+	private ImageService imageService;
+
+	@BeforeEach
+	void setUp() {
+		ImageController imageController = new ImageController(imageService);
+		mockMvc = MockMvcBuilders.standaloneSetup(imageController).setControllerAdvice(new GlobalExceptionHandler())
+			.build();
+		objectMapper = new ObjectMapper();
+	}
+
+	@Test
+	@DisplayName("이미지 업로드 API - 성공")
+	void addImageToTemp_success() throws Exception {
+		// given
+		MockMultipartFile mockFile = new MockMultipartFile("file", "test.png", "image/png", "hello".getBytes());
+		ImageIdResponse mockResponse = ImageIdResponse.from(1L);
+
+		when(imageService.addImageToTemp(any())).thenReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(multipart("/api/v1/image")
+				.file(mockFile)
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.imageId").value(1L));
+	}
+
+	@Test
+	@DisplayName("이미지 업로드 API - 실패 (파일 처리 중 예외 발생)")
+	void addImageToTemp_fail_dueToImageProcessing() throws Exception {
+		// given
+		MockMultipartFile mockFile = new MockMultipartFile("file", "bad.png", "image/png", "corrupted".getBytes());
+
+		when(imageService.addImageToTemp(any()))
+			.thenThrow(ImageException.from(ImageErrorCode.IMAGE_PROCESSING_FAIL));
+
+		// when & then
+		mockMvc.perform(multipart("/api/v1/image")
+				.file(mockFile)
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().is5xxServerError())
+			.andExpect(jsonPath("$.code").value(ImageErrorCode.IMAGE_PROCESSING_FAIL.getCode()))
+			.andExpect(jsonPath("$.message").exists());
+	}
+
+	@Test
+	@DisplayName("이미지 삭제 API - 성공")
+	void deleteImage_success() throws Exception {
+		// given
+		long imageId = 1L;
+		doNothing().when(imageService).deleteImage(imageId);
+
+		// when & then
+		mockMvc.perform(delete("/api/v1/image/{imageId}", imageId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("이미지 삭제 API - 실패 (존재하지 않는 이미지)")
+	void deleteImage_fail_notFound() throws Exception {
+		// given
+		long imageId = 999L;
+
+		doThrow(ImageException.from(ImageErrorCode.IMAGE_NOT_FOUND))
+			.when(imageService).deleteImage(imageId);
+
+		// when & then
+		mockMvc.perform(delete("/api/v1/image/{imageId}", imageId))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value(ImageErrorCode.IMAGE_NOT_FOUND.getCode()))
+			.andExpect(jsonPath("$.message").exists());
+	}
+}

--- a/src/test/java/com/example/cokathon/image/service/ImageServiceTest.java
+++ b/src/test/java/com/example/cokathon/image/service/ImageServiceTest.java
@@ -1,0 +1,100 @@
+package com.example.cokathon.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import com.example.cokathon.image.domain.Image;
+import com.example.cokathon.image.dto.ImageDTO;
+import com.example.cokathon.image.dto.S3InfoDTO;
+import com.example.cokathon.image.dto.response.ImageIdResponse;
+import com.example.cokathon.image.exception.ImageErrorCode;
+import com.example.cokathon.image.exception.ImageException;
+import com.example.cokathon.image.repository.ImageRepository;
+import com.example.cokathon.image.service.impl.ImageServiceImpl;
+import com.example.cokathon.image.service.s3.S3Uploader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ImageServiceTest {
+
+	private ImageService imageService;
+
+	@Mock
+	private ImageRepository imageRepository;
+
+	@Mock
+	private S3Uploader s3Uploader;
+
+	private final String TEMP_FOLDER = "temp";
+	private MockMultipartFile mockFile;
+
+	@BeforeEach
+	void setUp() {
+		mockFile = new MockMultipartFile("file", "test.png", "image/png", "dummy".getBytes());
+
+		imageService = new ImageServiceImpl(imageRepository, s3Uploader);
+	}
+
+	@Test
+	@DisplayName("이미지를 S3에 업로드하고 DB에 저장한 후 ID를 반환한다")
+	void addImageToTemp_success() {
+		// given
+		S3InfoDTO s3Info = S3InfoDTO.of("temp", "test.png", "https://s3.example.com/temp/test.png");
+		when(s3Uploader.uploadFiles(mockFile, TEMP_FOLDER)).thenReturn(s3Info);
+
+		Image image = Image.from(ImageDTO.from(s3Info));
+		when(imageRepository.save(any(Image.class))).thenReturn(image);
+
+		// when
+		ImageIdResponse result = imageService.addImageToTemp(mockFile);
+
+		// then
+		assertThat(result).isNotNull();
+		verify(s3Uploader).uploadFiles(mockFile, TEMP_FOLDER);
+		verify(imageRepository).save(any(Image.class));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 이미지 ID로 삭제를 시도하면 예외가 발생한다")
+	void deleteImage_imageNotFound() {
+		// given
+		long imageId = 1L;
+		when(imageRepository.findById(imageId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> imageService.deleteImage(imageId))
+			.isInstanceOf(ImageException.class)
+			.hasMessageContaining((ImageErrorCode.IMAGE_NOT_FOUND).getMessage());
+
+		verify(s3Uploader, never()).deleteFile(any(S3InfoDTO.class));
+		verify(imageRepository, never()).delete(any(Image.class));
+	}
+
+	@Test
+	@DisplayName("이미지를 삭제할 때 S3에서 파일을 삭제하고 DB에서도 제거한다")
+	void deleteImage_success() {
+		// given
+		S3InfoDTO s3Info = S3InfoDTO.of("temp", "test.png", "https://s3.example.com/temp/test.png");
+		Image image = Image.from(ImageDTO.from(s3Info));
+		ReflectionTestUtils.setField(image, "id", 1L);
+		when(imageRepository.findById(1L)).thenReturn(Optional.of(image));
+
+		// when
+		imageService.deleteImage(1L);
+
+		// then
+		verify(s3Uploader).deleteFile(s3Info);
+		verify(imageRepository).delete(image);
+	}
+}

--- a/src/test/java/com/example/cokathon/image/service/s3/S3UploaderTest.java
+++ b/src/test/java/com/example/cokathon/image/service/s3/S3UploaderTest.java
@@ -1,0 +1,88 @@
+package com.example.cokathon.image.service.s3;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.cokathon.image.dto.S3InfoDTO;
+import com.example.cokathon.image.exception.ImageErrorCode;
+import com.example.cokathon.image.exception.ImageException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class S3UploaderTest {
+
+    @InjectMocks
+    private S3Uploader s3Uploader;
+
+    @Mock
+    private AmazonS3Client amazonS3;
+
+    private final String BUCKET = "test-bucket";
+    private final String FOLDER = "temp";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(s3Uploader, "bucket", BUCKET);
+    }
+
+    @Test
+    @DisplayName("MultipartFile을 업로드하고 S3InfoDTO를 반환한다")
+    void uploadFiles_success() throws IOException {
+        // given
+        MockMultipartFile multipartFile =
+                new MockMultipartFile("file", "sample.png", "image/png", "test image".getBytes());
+
+        // mock: 업로드 이후 URL 반환
+        when(amazonS3.getUrl(anyString(), anyString()))
+                .thenReturn(new java.net.URL("https://s3.example.com/temp/sample.png"));
+
+        // when
+        S3InfoDTO result = s3Uploader.uploadFiles(multipartFile, FOLDER);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.folderName()).isEqualTo(FOLDER);
+        assertThat(result.url()).contains("https://s3.example.com");
+
+        // S3에 업로드가 실제로 호출됐는지 검증
+        verify(amazonS3).putObject(any(PutObjectRequest.class));
+    }
+
+    @Test
+    @DisplayName("S3에서 파일 삭제가 정상적으로 호출된다")
+    void deleteFile_success() {
+        // given
+        S3InfoDTO info = S3InfoDTO.of("temp", "sample.png", "https://s3.example.com/temp/sample.png");
+
+        // when
+        s3Uploader.deleteFile(info);
+
+        // then
+        verify(amazonS3).deleteObject(BUCKET, "temp/sample.png");
+    }
+
+    @Test
+    @DisplayName("확장자 추출 실패 시 예외가 발생한다")
+    void extractExtension_fail() {
+        // given
+        MockMultipartFile noExtFile = new MockMultipartFile("file", "invalidfile", "image/png", "data".getBytes());
+
+        // when & then
+        assertThatThrownBy(() -> {
+            // private method는 reflection으로 접근해야 한다.
+            ReflectionTestUtils.invokeMethod(s3Uploader, "extractExtension", noExtFile);
+        }).isInstanceOf(ImageException.class).hasMessageContaining(ImageErrorCode.IMAGE_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #1 

## 📝작업 내용

S3 이미지 업로드 및 삭제 기능을 도입하고, 공통 응답 포맷 및 예외 처리 구조를 구성했습니다.
또한 테스트 코드와 엔티티 생성일 자동 설정 기능도 함께 추가했습니다.

📌 주요 변경 사항
- S3Uploader, S3Config 구현: S3에 이미지 업로드 및 삭제 가능
- Image 엔티티 및 CRUD API 구현: 이미지 등록/삭제 가능
- 공통 응답 클래스 (DataResponse, ErrorResponse) 적용
- GlobalExceptionHandler 및 커스텀 예외 구조 도입
- BaseEntity 생성 및 createdDate 자동 설정 적용
- 업로드/삭제 기능에 대한 단위 테스트 작성

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?