### PR TITLE
[Feat] JWT 인증 및 회원가입/로그인, 토큰 재발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.springframework.boot' version '3.3.5'
+	id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.example'
@@ -43,6 +43,26 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	// serialization
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/cokathon/global/auth/dto/JwtTokenResponse.java
+++ b/src/main/java/com/example/cokathon/global/auth/dto/JwtTokenResponse.java
@@ -1,0 +1,21 @@
+package com.example.cokathon.global.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class JwtTokenResponse {
+
+	private final String grantType; // JWT 토큰 타입 (Bearer)
+	private final String accessToken;
+	private final String refreshToken;
+
+	private JwtTokenResponse(String grantType, String accessToken, String refreshToken) {
+		this.grantType = grantType;
+		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
+	}
+
+	public static JwtTokenResponse of(String grantType, String accessToken, String refreshToken) {
+		return new JwtTokenResponse(grantType, accessToken, refreshToken);
+	}
+}

--- a/src/main/java/com/example/cokathon/global/auth/jwt/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/cokathon/global/auth/jwt/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.example.cokathon.global.auth.jwt.exception;
+
+import static com.example.cokathon.user.exception.UserErrorCode.*;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import com.example.cokathon.global.dto.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+			throws IOException {
+		ErrorResponse errorResponse = ErrorResponse.of(
+			FORBIDDEN_ACCESS.getHttpStatus(),
+			FORBIDDEN_ACCESS.getMessage(),
+			FORBIDDEN_ACCESS.getCode()
+		);
+
+		response.setStatus(HttpStatus.FORBIDDEN.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+	}
+}

--- a/src/main/java/com/example/cokathon/global/auth/jwt/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/cokathon/global/auth/jwt/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.example.cokathon.global.auth.jwt.exception;
+
+import static com.example.cokathon.user.exception.UserErrorCode.*;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import com.example.cokathon.global.dto.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+			throws IOException {
+		ErrorResponse errorResponse = ErrorResponse.of(
+			UNAUTHORIZED_ACCESS.getHttpStatus(),
+			UNAUTHORIZED_ACCESS.getMessage(),
+			UNAUTHORIZED_ACCESS.getCode()
+		);
+
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+	}
+}
+

--- a/src/main/java/com/example/cokathon/global/auth/jwt/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/example/cokathon/global/auth/jwt/exception/ExceptionHandlerFilter.java
@@ -1,0 +1,67 @@
+package com.example.cokathon.global.auth.jwt.exception;
+
+import static com.example.cokathon.global.exception.GlobalErrorCode.*;
+import static com.example.cokathon.user.exception.UserErrorCode.*;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.example.cokathon.global.dto.ErrorResponse;
+import com.example.cokathon.user.exception.UserException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+
+		} catch (UserException e) {
+			setErrorResponse(response, e.getHttpStatus().value(), e.getMessage(), e.getCode());
+
+		} catch (ExpiredJwtException e) {
+			setErrorResponse(response, 401, EXPIRED_TOKEN.getMessage(), EXPIRED_TOKEN.getCode());
+
+		} catch (JwtException | IllegalArgumentException e) {
+			setErrorResponse(response, 401, INVALID_TOKEN.getMessage(), INVALID_TOKEN.getCode());
+
+		} catch (RuntimeException e) {
+			setErrorResponse(response, 500, INTERNAL_SERVER_ERROR.getMessage(), INTERNAL_SERVER_ERROR.getCode());
+		}
+	}
+
+	private void setErrorResponse(HttpServletResponse response, int status, String message, String code) {
+		try {
+			ErrorResponse errorResponse = ErrorResponse.of(
+				HttpStatus.valueOf(status), message, code
+			);
+
+			response.setStatus(status);
+			response.setContentType("application/json");
+			response.setCharacterEncoding("UTF-8");
+			response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+		} catch (IOException e) {
+			log.error("Error writing error response: {}", e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/example/cokathon/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/cokathon/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.example.cokathon.global.auth.jwt.filter;
+
+import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+
+import com.example.cokathon.global.auth.jwt.service.JwtTokenProvider;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.GenericFilter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilter {
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
+		IOException, ServletException {
+
+		// Request Header에서 JWT 토큰 추출
+		String accessToken = resolveToken((HttpServletRequest)request);
+
+		// accessToken 유효성 검사하기
+		if (accessToken != null) {
+			if (jwtTokenProvider.validateToken(accessToken)) {
+				// 토큰이 유효할 경우, 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장함
+				Authentication authentication = jwtTokenProvider.getAuthentication(accessToken); // 토큰에 있는 정보 꺼내기
+				SecurityContextHolder.getContext().setAuthentication(authentication); // 현재 실행 중인 스레드에 인증 정보를 저장
+			} else {
+				// 토큰이 유효하지 않은 경우, 더 이상의 필터 처리 하지 않음
+				HttpServletResponse httpResponse = (HttpServletResponse)response;
+				httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 인증 정보 부족
+				return;
+			}
+		}
+		chain.doFilter(request, response); // 다음 필터로 요청 전달
+	}
+
+	// Request Header에서 JWT 토큰 추출
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader("Authorization");
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+			return bearerToken.substring(7); // "Bearer " 이후만 넘기기
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/example/cokathon/global/auth/jwt/service/CustomUserDetailService.java
+++ b/src/main/java/com/example/cokathon/global/auth/jwt/service/CustomUserDetailService.java
@@ -1,0 +1,31 @@
+package com.example.cokathon.global.auth.jwt.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import com.example.cokathon.user.domain.User;
+import com.example.cokathon.user.exception.UserErrorCode;
+import com.example.cokathon.user.exception.UserException;
+import com.example.cokathon.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	// pk 받아서 해당 유저를 찾아 CustomUserDetails로 반환
+	@Override
+	public UserDetails loadUserByUsername(String id) {
+		User user = userRepository.findById(Long.parseLong(id))
+			.orElseThrow(() -> UserException.from(UserErrorCode.USER_NOT_FOUND));
+
+		return CustomUserDetails.of(
+			user.getId(),
+			user.getRole().name()
+		);
+	}
+}

--- a/src/main/java/com/example/cokathon/global/auth/jwt/service/CustomUserDetails.java
+++ b/src/main/java/com/example/cokathon/global/auth/jwt/service/CustomUserDetails.java
@@ -1,0 +1,65 @@
+package com.example.cokathon.global.auth.jwt.service;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class CustomUserDetails implements UserDetails {
+
+	private final String username;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	private CustomUserDetails(String username, Collection<? extends GrantedAuthority> authorities) {
+		this.username = username;
+		this.authorities = authorities;
+	}
+
+	public static CustomUserDetails of(Long userId, String roleName) {
+		return new CustomUserDetails(
+			userId.toString(),
+			List.of(new SimpleGrantedAuthority(roleName))
+		);
+	}
+
+	public static CustomUserDetails of(Long userId, Collection<? extends GrantedAuthority> authorities) {
+		return new CustomUserDetails(userId.toString(), authorities);
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getPassword() {
+		return ""; // 비밀번호는 사용하지 않음
+	}
+
+	@Override
+	public String getUsername() {
+		return username;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/example/cokathon/global/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/com/example/cokathon/global/auth/jwt/service/JwtTokenProvider.java
@@ -1,0 +1,164 @@
+package com.example.cokathon.global.auth.jwt.service;
+
+import java.security.Key;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import com.example.cokathon.global.auth.dto.JwtTokenResponse;
+import com.example.cokathon.global.redis.RedisDao;
+import com.example.cokathon.user.exception.UserErrorCode;
+import com.example.cokathon.user.exception.UserException;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+	private static final String GRANT_TYPE = "Bearer";
+	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24; // 24시간
+	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 3; // 3일
+
+	private final Key key;
+	private final UserDetailsService userDetailsService;
+	private final RedisDao redisDao;
+
+	public JwtTokenProvider(@Value("${jwt.secret}") String secretKey,
+		UserDetailsService userDetailsService,
+		RedisDao redisDao) {
+		byte[] keyBytes = Base64.getEncoder().encode(secretKey.getBytes());
+		this.key = Keys.hmacShaKeyFor(keyBytes);
+		this.userDetailsService = userDetailsService;
+		this.redisDao = redisDao;
+	}
+
+	public JwtTokenResponse generateToken(Authentication authentication) {
+		String authorities = authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
+
+		String username = authentication.getName();
+		return getJwtToken(authorities, username);
+	}
+
+	public JwtTokenResponse generateTokenWithRefreshToken(String username) {
+		UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+		String authorities = userDetails.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
+
+		return getJwtToken(authorities, username);
+	}
+
+	private JwtTokenResponse getJwtToken(String authorities, String username) {
+		long now = System.currentTimeMillis();
+
+		String accessToken = generateAccessToken(username, authorities, new Date(now + ACCESS_TOKEN_EXPIRE_TIME));
+		String refreshToken = generateRefreshToken(username, new Date(now + REFRESH_TOKEN_EXPIRE_TIME));
+
+		redisDao.setValues(username, refreshToken, Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
+		return JwtTokenResponse.of(GRANT_TYPE, accessToken, refreshToken);
+	}
+
+	private String generateAccessToken(String username, String authorities, Date expireDate) {
+		return Jwts.builder()
+			.setSubject(username)
+			.claim("auth", authorities)
+			.setExpiration(expireDate)
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	private String generateRefreshToken(String username, Date expireDate) {
+		return Jwts.builder()
+			.setSubject(username)
+			.setExpiration(expireDate)
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public Authentication getAuthentication(String token) {
+		Claims claims = parseClaims(token);
+		if (claims.get("auth") == null) {
+			throw UserException.from(UserErrorCode.UNAUTHORIZED_ACCESS);
+		}
+
+		Collection<? extends GrantedAuthority> authorities =
+			Arrays.stream(claims.get("auth").toString().split(","))
+				.map(SimpleGrantedAuthority::new)
+				.toList();
+
+		UserDetails principal = CustomUserDetails.of(
+			Long.parseLong(claims.getSubject()), authorities
+		);
+
+		return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+	}
+
+	private Claims parseClaims(String token) {
+		try {
+			return Jwts.parserBuilder().setSigningKey(key).build()
+				.parseClaimsJws(token).getBody();
+		} catch (ExpiredJwtException e) {
+			return e.getClaims();
+		} catch (JwtException e) {
+			throw UserException.from(UserErrorCode.INVALID_TOKEN);
+		}
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			return true;
+		} catch (JwtException e) {
+			log.warn("JWT Token Error: {}", e.getMessage());
+			throw UserException.from(UserErrorCode.INVALID_TOKEN);
+		}
+	}
+
+	public boolean validateRefreshToken(String token) {
+		if (!validateToken(token))
+			return false;
+
+		try {
+			String username = getUserNameFromToken(token);
+			String storedToken = (String)redisDao.getValues(username);
+			return token.equals(storedToken);
+		} catch (Exception e) {
+			throw UserException.from(UserErrorCode.INVALID_REFRESH_TOKEN);
+		}
+	}
+
+	public String getUserNameFromToken(String token) {
+		try {
+			return Jwts.parserBuilder().setSigningKey(key).build()
+				.parseClaimsJws(token).getBody().getSubject();
+		} catch (ExpiredJwtException e) {
+			return e.getClaims().getSubject();
+		} catch (JwtException e) {
+			throw UserException.from(UserErrorCode.INVALID_TOKEN);
+		}
+	}
+
+	public void deleteRefreshToken(String username) {
+		if (username == null || username.isBlank()) {
+			throw UserException.from(UserErrorCode.INVALID_REFRESH_TOKEN);
+		}
+		redisDao.deleteValues(username);
+	}
+}

--- a/src/main/java/com/example/cokathon/global/config/JacksonConfig.java
+++ b/src/main/java/com/example/cokathon/global/config/JacksonConfig.java
@@ -1,0 +1,20 @@
+package com.example.cokathon.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JacksonConfig {
+	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.enable(SerializationFeature.INDENT_OUTPUT);
+		return objectMapper;
+	}
+}

--- a/src/main/java/com/example/cokathon/global/config/RedisConfig.java
+++ b/src/main/java/com/example/cokathon/global/config/RedisConfig.java
@@ -1,0 +1,54 @@
+package com.example.cokathon.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.beans.factory.annotation.Value;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    // Redis 연결 팩토리 설정
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+
+        // Lettuce 라이브러리를 사용해서 Redis에 연결
+        // Lettuce는 Jedis보다 성능이 좋고 비동기 처리가 가능함
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    // RedisTemplate 설정
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        // RedisTemplate는 트랜잭션을 지원함
+        // 트랜잭션 안에서 오류가 발생하면 그 작업을 모두 취소함
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // key, value에 대한 직렬화 방법 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // hash key, hash value에 대한 직렬화 방법 설정
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/cokathon/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/cokathon/global/config/SecurityConfig.java
@@ -1,0 +1,65 @@
+package com.example.cokathon.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.example.cokathon.global.auth.jwt.exception.ExceptionHandlerFilter;
+import com.example.cokathon.global.auth.jwt.filter.JwtAuthenticationFilter;
+import com.example.cokathon.global.auth.jwt.service.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final ObjectMapper objectMapper;
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.formLogin(AbstractHttpConfigurer::disable)
+			.logout(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				// 1. DELETE /api/v1/auth/user 는 ADMIN만 허용
+				.requestMatchers(HttpMethod.DELETE, "/api/v1/auth/user").hasRole("ADMIN")
+
+				// 2. 로그인, 회원가입 등 인증 없이 허용
+				.requestMatchers(
+					"/api/v1/auth/**",
+					"/swagger-ui/**",
+					"/v3/api-docs/**"
+				).permitAll()
+
+				// 3. 그 외 모든 요청은 인증 필요
+				.anyRequest().authenticated()
+			)
+			.addFilterBefore(
+				new JwtAuthenticationFilter(jwtTokenProvider),
+				UsernamePasswordAuthenticationFilter.class
+			)
+			.addFilterBefore(new ExceptionHandlerFilter(objectMapper), JwtAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/com/example/cokathon/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/cokathon/global/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.example.cokathon.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		SecurityScheme securityScheme =
+			new SecurityScheme()
+				.type(SecurityScheme.Type.HTTP)
+				.scheme("bearer")
+				.bearerFormat("JWT")
+				.in(SecurityScheme.In.HEADER)
+				.name("Authorization");
+
+		SecurityRequirement securityRequirement = new SecurityRequirement().addList("BearerAuth");
+
+		return new OpenAPI()
+			.components(new Components().addSecuritySchemes("BearerAuth", securityScheme))
+			.info(
+				new Info()
+					.title("cokathon REST API")
+					.description("cokathon Swagger")
+					.version("1.0.0"))
+			.addSecurityItem(securityRequirement);
+	}
+}
+

--- a/src/main/java/com/example/cokathon/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/cokathon/global/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.example.cokathon.global.dto.ErrorResponse;
 import com.example.cokathon.image.exception.ImageException;
+import com.example.cokathon.user.exception.UserException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,6 +36,15 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(ImageException.class)
 	public ResponseEntity<Object> handleImageException(ImageException e) {
 		log.error("ImageException: {}", e.getMessage(), e);
+
+		return ResponseEntity
+			.status(e.getHttpStatus())
+			.body(ErrorResponse.of(e.getHttpStatus(), e.getMessage(), e.getCode()));
+	}
+
+	@ExceptionHandler(UserException.class)
+	public ResponseEntity<Object> handleUserException(UserException e) {
+		log.error("UserException: {}", e.getMessage(), e);
 
 		return ResponseEntity
 			.status(e.getHttpStatus())

--- a/src/main/java/com/example/cokathon/global/redis/RedisDao.java
+++ b/src/main/java/com/example/cokathon/global/redis/RedisDao.java
@@ -1,0 +1,38 @@
+package com.example.cokathon.global.redis;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisDao {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ValueOperations<String, Object> values;
+
+    public RedisDao(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        this.values = redisTemplate.opsForValue(); // String 타입을 쉽게 처리하는 메서드
+    }
+
+    // 기본 데이터 저장
+    public void setValues(String key, String data) {
+        values.set(key, data);
+    }
+
+    // 만료 시간이 있는 데이터 저장
+    public void setValues(String key, String data, Duration duration) {
+        values.set(key, data, duration);
+    }
+
+    // 데이터 조회
+    public Object getValues(String key) {
+        return values.get(key);
+    }
+
+    // 데이터 삭제
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/example/cokathon/user/controller/AuthController.java
+++ b/src/main/java/com/example/cokathon/user/controller/AuthController.java
@@ -1,0 +1,53 @@
+package com.example.cokathon.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.cokathon.global.auth.dto.JwtTokenResponse;
+import com.example.cokathon.global.dto.DataResponse;
+import com.example.cokathon.user.dto.request.LoginRequest;
+import com.example.cokathon.user.dto.request.SignUpRequest;
+import com.example.cokathon.user.dto.request.TokenReissueRequest;
+import com.example.cokathon.user.service.UserService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/v1/auth")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final UserService userService;
+
+	@PostMapping("/signup")
+	public ResponseEntity<DataResponse<Void>> signUp(@Valid @RequestBody SignUpRequest request) {
+
+		userService.createUser(request.email(), request.password());
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<DataResponse<JwtTokenResponse>> login(@Valid @RequestBody LoginRequest request) {
+
+		JwtTokenResponse jwtToken = userService.login(request.email(), request.password());
+		return ResponseEntity.ok(DataResponse.from(jwtToken));
+	}
+
+	@PostMapping("/reissue")
+	public ResponseEntity<DataResponse<JwtTokenResponse>> reissue(@Valid @RequestBody TokenReissueRequest request) {
+
+		JwtTokenResponse jwtToken = userService.reissue(request.refreshToken());
+		return ResponseEntity.ok(DataResponse.from(jwtToken));
+	}
+
+	@DeleteMapping("/user")
+	public ResponseEntity<DataResponse<Void>> deleteUser(@Valid @RequestBody TokenReissueRequest request) {
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+}

--- a/src/main/java/com/example/cokathon/user/domain/Role.java
+++ b/src/main/java/com/example/cokathon/user/domain/Role.java
@@ -1,0 +1,7 @@
+package com.example.cokathon.user.domain;
+
+public enum Role {
+    ROLE_USER,
+    ROLE_ADMIN
+}
+

--- a/src/main/java/com/example/cokathon/user/domain/User.java
+++ b/src/main/java/com/example/cokathon/user/domain/User.java
@@ -1,0 +1,50 @@
+package com.example.cokathon.user.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "users")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+	private User(String email, String password, Role role) {
+		this.email = email;
+		this.password = password;
+		this.role = role;
+	}
+
+    public static User toUser(String email, String password) {
+		return new User(
+			email,
+			password,
+			Role.ROLE_USER
+		);
+	}
+
+	public static User toAdminUser(String email, String password) {
+		return new User(
+			email,
+			password,
+			Role.ROLE_ADMIN
+		);
+	}
+}

--- a/src/main/java/com/example/cokathon/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/cokathon/user/dto/request/LoginRequest.java
@@ -1,0 +1,7 @@
+package com.example.cokathon.user.dto.request;
+
+public record LoginRequest(
+	String email,
+	String password
+) {
+}

--- a/src/main/java/com/example/cokathon/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/example/cokathon/user/dto/request/SignUpRequest.java
@@ -1,0 +1,7 @@
+package com.example.cokathon.user.dto.request;
+
+public record SignUpRequest(
+	String email,
+	String password
+) {
+}

--- a/src/main/java/com/example/cokathon/user/dto/request/TokenReissueRequest.java
+++ b/src/main/java/com/example/cokathon/user/dto/request/TokenReissueRequest.java
@@ -1,0 +1,5 @@
+package com.example.cokathon.user.dto.request;
+
+public record TokenReissueRequest(
+    String refreshToken
+) {}

--- a/src/main/java/com/example/cokathon/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/cokathon/user/exception/UserErrorCode.java
@@ -1,0 +1,32 @@
+package com.example.cokathon.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode {
+
+	// 사용자 관련 예외 코드
+
+	// 404 Not Found
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.", "USER_ERROR_404_NOT_FOUND"),
+	USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다.", "USER_ERROR_409_ALREADY_EXISTS"),
+
+	// 401 Unauthorized
+	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "잘못된 비밀번호입니다.", "USER_ERROR_401_INVALID_PASSWORD"),
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.", "USER_ERROR_401_INVALID_TOKEN"),
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다.", "USER_ERROR_401_INVALID_REFRESH_TOKEN"),
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.", "USER_ERROR_401_EXPIRED_TOKEN"),
+	UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 접근입니다.", "USER_ERROR_401_UNAUTHORIZED_ACCESS"),
+
+	// 403 Forbidden
+	FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근이 금지되었습니다.", "USER_ERROR_403_FORBIDDEN_ACCESS");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+	private final String code;
+
+}

--- a/src/main/java/com/example/cokathon/user/exception/UserException.java
+++ b/src/main/java/com/example/cokathon/user/exception/UserException.java
@@ -1,0 +1,23 @@
+package com.example.cokathon.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class UserException extends RuntimeException {
+
+	private final HttpStatus httpStatus;
+	private final String code;
+
+	private UserException(String message, HttpStatus httpStatus, String code) {
+		super(message);
+		this.httpStatus = httpStatus;
+		this.code = code;
+	}
+
+	public static UserException from(UserErrorCode errorCode) {
+		return new UserException(errorCode.getMessage(), errorCode.getHttpStatus(), errorCode.getCode());
+	}
+}
+

--- a/src/main/java/com/example/cokathon/user/repository/UserRepository.java
+++ b/src/main/java/com/example/cokathon/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.cokathon.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.cokathon.user.domain.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/example/cokathon/user/service/UserService.java
+++ b/src/main/java/com/example/cokathon/user/service/UserService.java
@@ -1,0 +1,12 @@
+package com.example.cokathon.user.service;
+
+import com.example.cokathon.global.auth.dto.JwtTokenResponse;
+
+public interface UserService {
+
+	void createUser(String email, String password);
+
+	JwtTokenResponse login(String email, String password);
+
+	JwtTokenResponse reissue(String refreshToken);
+}

--- a/src/main/java/com/example/cokathon/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/cokathon/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,71 @@
+package com.example.cokathon.user.service.impl;
+
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.cokathon.global.auth.jwt.service.JwtTokenProvider;
+import com.example.cokathon.global.auth.dto.JwtTokenResponse;
+import com.example.cokathon.user.domain.User;
+import com.example.cokathon.user.exception.UserErrorCode;
+import com.example.cokathon.user.exception.UserException;
+import com.example.cokathon.user.repository.UserRepository;
+import com.example.cokathon.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	@Transactional
+	public void createUser(String email, String password) {
+		userRepository.findByEmail(email)
+			.ifPresent(user -> {
+				throw UserException.from(UserErrorCode.USER_ALREADY_EXISTS);
+			});
+
+		String encodedPassword = passwordEncoder.encode(password);
+
+		userRepository.save(User.toUser(email, encodedPassword));
+
+	}
+
+	@Override
+	public JwtTokenResponse login(String email, String password) {
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> UserException.from(UserErrorCode.USER_NOT_FOUND));
+
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw UserException.from(UserErrorCode.INVALID_PASSWORD);
+		}
+
+		// 인증 객체 생성
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+			user.getId().toString(), null, List.of(new SimpleGrantedAuthority(user.getRole().name()))
+		);
+
+		return jwtTokenProvider.generateToken(authentication);
+	}
+
+	@Override
+	public JwtTokenResponse reissue(String refreshToken) {
+		if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+			throw UserException.from(UserErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
+		String username = jwtTokenProvider.getUserNameFromToken(refreshToken);
+		return jwtTokenProvider.generateTokenWithRefreshToken(username);
+	}
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,13 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #3

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- JWT 기반 인증 필터 및 토큰 발급/검증 로직 구현 (JwtAuthenticationFilter, JwtTokenProvider)
- AccessDeniedHandler, AuthenticationEntryPoint 커스터마이징하여 인증/인가 실패 시 응답 처리
- 회원가입/로그인/토큰 재발급 API 구현 (AuthController, UserServiceImpl)
- Redis를 통한 RefreshToken 저장소 구성 (RedisDao, RedisConfig)
- 사용자 인증 정보 관리 및 UserDetailsService 구현 (CustomUserDetails, CustomUserDetailService)
- Swagger에 JWT 인증 헤더 설정 추가 (SwaggerConfig)
- 전역 예외 처리 핸들러 구현 및 사용자 예외 정의 (GlobalExceptionHandler, UserException, UserErrorCode)
- application.yml에 Redis 및 JWT 관련 설정 추가
- LocalDateTime 직렬화를 위한 Jackson 설정 추가 (JacksonConfig)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?